### PR TITLE
Add support for self-signed certificates to NeoConnection

### DIFF
--- a/src/main/java/org/neo4j/hop/shared/NeoConnection.java
+++ b/src/main/java/org/neo4j/hop/shared/NeoConnection.java
@@ -74,6 +74,12 @@ public class NeoConnection extends Variables implements IHopMetadata {
   private String usingEncryptionVariable;
 
   @HopMetadataProperty
+  private boolean trustAllCertificates;
+
+  @HopMetadataProperty
+  private String trustAllCertificatesVariable;
+
+  @HopMetadataProperty
   private List<String> manualUrls;
 
   @HopMetadataProperty
@@ -111,6 +117,7 @@ public class NeoConnection extends Variables implements IHopMetadata {
     this();
     super.initializeVariablesFrom( parent );
     usingEncryption = true;
+    trustAllCertificates = false;
   }
 
   public NeoConnection( IVariables parent, NeoConnection source ) {
@@ -126,6 +133,8 @@ public class NeoConnection extends Variables implements IHopMetadata {
     this.password = source.password;
     this.usingEncryption = source.usingEncryption;
     this.usingEncryptionVariable = source.usingEncryptionVariable;
+    this.trustAllCertificates = source.trustAllCertificates;
+    this.trustAllCertificatesVariable = source.trustAllCertificatesVariable;
     this.connectionLivenessCheckTimeout = source.connectionLivenessCheckTimeout;
     this.maxConnectionLifetime = source.maxConnectionLifetime;
     this.maxConnectionPoolSize = source.maxConnectionPoolSize;
@@ -313,6 +322,16 @@ public class NeoConnection extends Variables implements IHopMetadata {
     return false;
   }
 
+  public boolean trustAllCertificatesVariableSet() {
+    if ( !Utils.isEmpty( trustAllCertificatesVariable ) ) {
+      String value = environmentSubstitute( trustAllCertificatesVariable );
+      if ( !Utils.isEmpty( value ) ) {
+        return ValueMetaString.convertStringToBoolean( value );
+      }
+    }
+    return false;
+  }
+
   public boolean version4VariableSet() {
     if ( !Utils.isEmpty( version4Variable ) ) {
       String value = environmentSubstitute( version4Variable );
@@ -335,6 +354,9 @@ public class NeoConnection extends Variables implements IHopMetadata {
       Config.ConfigBuilder configBuilder;
       if ( encryptionVariableSet() || usingEncryption ) {
         configBuilder = Config.builder().withEncryption();
+        if ( trustAllCertificatesVariableSet() || trustAllCertificates ) {
+          configBuilder = configBuilder.withTrustStrategy(Config.TrustStrategy.trustAllCertificates());
+        }
       } else {
         configBuilder = Config.builder().withoutEncryption();
       }
@@ -574,6 +596,22 @@ public class NeoConnection extends Variables implements IHopMetadata {
   }
 
   /**
+   * Gets usingTrustAllCertificates
+   *
+   * @return value of usingTrustAllCertificates
+   */
+  public boolean isTrustAllCertificates() {
+    return trustAllCertificates;
+  }
+
+  /**
+   * @param trustAllCertificates The trustAllCertificates to set
+   */
+  public void setTrustAllCertificates( boolean trustAllCertificates ) {
+    this.trustAllCertificates = trustAllCertificates;
+  }
+
+  /**
    * Gets manualUrls
    *
    * @return value of manualUrls
@@ -715,6 +753,22 @@ public class NeoConnection extends Variables implements IHopMetadata {
    */
   public void setUsingEncryptionVariable( String usingEncryptionVariable ) {
     this.usingEncryptionVariable = usingEncryptionVariable;
+  }
+
+  /**
+   * Gets trustAllCertificatesVariable
+   *
+   * @return value of trustAllCertificatesVariable
+   */
+  public String getTrustAllCertificatesVariable() {
+    return trustAllCertificatesVariable;
+  }
+
+  /**
+   * @param trustAllCertificatesVariable The trustAllCertificatesVariable to set
+   */
+  public void setTrustAllCertificatesVariable( String trustAllCertificatesVariable ) {
+    this.trustAllCertificatesVariable = trustAllCertificatesVariable;
   }
 
   /**

--- a/src/main/java/org/neo4j/hop/shared/NeoConnectionDialog.java
+++ b/src/main/java/org/neo4j/hop/shared/NeoConnectionDialog.java
@@ -70,6 +70,8 @@ public class NeoConnectionDialog implements IMetadataDialog {
   private CheckBoxVar wRouting;
   private Label wlEncryption;
   private CheckBoxVar wEncryption;
+  private Label wlTrustAllCertificates;
+  private CheckBoxVar wTrustAllCertificates;
 
   Control lastControl;
 
@@ -381,6 +383,24 @@ public class NeoConnectionDialog implements IMetadataDialog {
     wEncryption.setLayoutData( fdEncryption );
     lastControl = wEncryption;
 
+    // Trust Level?
+    wlTrustAllCertificates = new Label( shell, SWT.RIGHT );
+    wlTrustAllCertificates.setText( BaseMessages.getString( PKG, "NeoConnectionDialog.TrustAllCertificates.Label" ) );
+    props.setLook( wlTrustAllCertificates );
+    FormData fdlTrustAllCertificates = new FormData();
+    fdlTrustAllCertificates.top = new FormAttachment( lastControl, margin );
+    fdlTrustAllCertificates.left = new FormAttachment( 0, 0 );
+    fdlTrustAllCertificates.right = new FormAttachment( middle, -margin );
+    wlTrustAllCertificates.setLayoutData( fdlTrustAllCertificates );
+    wTrustAllCertificates = new CheckBoxVar( neoConnection, shell, SWT.CHECK );
+    props.setLook( wEncryption );
+    FormData fdTrustAllCertificates = new FormData();
+    fdTrustAllCertificates.top = new FormAttachment( wlTrustAllCertificates, 0, SWT.CENTER );
+    fdTrustAllCertificates.left = new FormAttachment( middle, 0 );
+    fdTrustAllCertificates.right = new FormAttachment( 95, 0 );
+    wTrustAllCertificates.setLayoutData( fdTrustAllCertificates );
+    lastControl = wlTrustAllCertificates;
+
     gAdvanced = new Group( shell, SWT.SHADOW_ETCHED_IN );
     props.setLook( gAdvanced );
     FormLayout advancedLayout = new FormLayout();
@@ -593,6 +613,8 @@ public class NeoConnectionDialog implements IMetadataDialog {
     wPassword.setText( Const.NVL( neoConnection.getPassword(), "" ) );
     wEncryption.setSelection( neoConnection.isUsingEncryption() );
     wEncryption.setVariableName( Const.NVL(neoConnection.getUsingEncryptionVariable(), "") );
+    wTrustAllCertificates.setSelection( neoConnection.isTrustAllCertificates() );
+    wTrustAllCertificates.setVariableName( Const.NVL(neoConnection.getTrustAllCertificatesVariable(), "") );
     wConnectionLivenessCheckTimeout.setText( Const.NVL( neoConnection.getConnectionLivenessCheckTimeout(), "" ) );
     wMaxConnectionLifetime.setText( Const.NVL( neoConnection.getMaxConnectionLifetime(), "" ) );
     wMaxConnectionPoolSize.setText( Const.NVL( neoConnection.getMaxConnectionPoolSize(), "" ) );
@@ -644,6 +666,8 @@ public class NeoConnectionDialog implements IMetadataDialog {
     neo.setPassword( wPassword.getText() );
     neo.setUsingEncryption( wEncryption.getSelection() );
     neo.setUsingEncryptionVariable( wEncryption.getVariableName() );
+    neo.setTrustAllCertificates( wTrustAllCertificates.getSelection() );
+    neo.setTrustAllCertificatesVariable( wTrustAllCertificates.getVariableName() );
 
     neo.setConnectionLivenessCheckTimeout( wConnectionLivenessCheckTimeout.getText() );
     neo.setMaxConnectionLifetime( wMaxConnectionLifetime.getText() );

--- a/src/main/java/org/neo4j/hop/shared/messages/messages_en_US.properties
+++ b/src/main/java/org/neo4j/hop/shared/messages/messages_en_US.properties
@@ -10,6 +10,7 @@ NeoConnectionDialog.Policy.Label=Routing Policy
 NeoConnectionDialog.UserName.Label=Username
 NeoConnectionDialog.Password.Label=Password
 NeoConnectionDialog.Encryption.Label=Use encryption?
+NeoConnectionDialog.TrustAllCertificates.Label=Trust all certificates?
 NeoConnectionDialog.URLs.Label=Manual URLs
 NeoConnectionDialog.URLColumn.Label = URL
 


### PR DESCRIPTION
Add a new configuration property to `NeoConnection` (and matching checkbox to the `NeoConnectionDialog` ui) for toggling a trust strategy for trusting all certificates. This allows users to easily mimic using the `bolt+ssc://` and `neo4j+ssc://` schemes.

Note: This does NOT add support for the more complicated trust strategy of providing a signature File to determine trust.

Tested manually with both Neo4j 3.5, 4.1, 4.2, and Aura.